### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 [![Board Status](https://dev.azure.com/IntellipaatOrganisation/27f55988-93c5-4b8e-8b04-992d5da863fb/31bb33bc-499f-4205-8031-a87e19672140/_apis/work/boardbadge/1eecaa63-4c9b-4000-964e-653dd2295c41)](https://dev.azure.com/IntellipaatOrganisation/27f55988-93c5-4b8e-8b04-992d5da863fb/_boards/board/t/31bb33bc-499f-4205-8031-a87e19672140/Microsoft.RequirementCategory)
 # git-github
 This is tutorial purpose.
+AB #1

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/IntellipaatOrganisation/27f55988-93c5-4b8e-8b04-992d5da863fb/31bb33bc-499f-4205-8031-a87e19672140/_apis/work/boardbadge/1eecaa63-4c9b-4000-964e-653dd2295c41)](https://dev.azure.com/IntellipaatOrganisation/27f55988-93c5-4b8e-8b04-992d5da863fb/_boards/board/t/31bb33bc-499f-4205-8031-a87e19672140/Microsoft.RequirementCategory)
 # git-github
 This is tutorial purpose.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 [![Board Status](https://dev.azure.com/IntellipaatOrganisation/27f55988-93c5-4b8e-8b04-992d5da863fb/31bb33bc-499f-4205-8031-a87e19672140/_apis/work/boardbadge/1eecaa63-4c9b-4000-964e-653dd2295c41)](https://dev.azure.com/IntellipaatOrganisation/27f55988-93c5-4b8e-8b04-992d5da863fb/_boards/board/t/31bb33bc-499f-4205-8031-a87e19672140/Microsoft.RequirementCategory)
 # git-github
 This is tutorial purpose.
-AB #1
+AB#1


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/IntellipaatOrganisation/27f55988-93c5-4b8e-8b04-992d5da863fb/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.